### PR TITLE
Fix Windows wallpaper caching, not updating

### DIFF
--- a/walltaker.go
+++ b/walltaker.go
@@ -89,25 +89,6 @@ func getWallpaperUrlFromData(userData WalltakerData) (string, error) {
 	return userData.PostURL.String, nil
 }
 
-func RemoveContents(dir string) error {
-	d, err := os.Open(dir)
-	if err != nil {
-		return err
-	}
-	defer d.Close()
-	names, err := d.Readdirnames(-1)
-	if err != nil {
-		return err
-	}
-	for _, name := range names {
-		err = os.RemoveAll(filepath.Join(dir, name))
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func clearWindowsWallpaperCache() {
 	// Remove cached wallpaper files, issue #12
 	if runtime.GOOS == "windows" {


### PR DESCRIPTION
- Clears cached files from user's roaming profile directory, which closes #12 
- Also changes logic that sets wallpaper to `""` filepath for the macOS bug fix - run on NON windows systems only (no need to flash to black and then back on Windows if it isn't necessary, not sure how necessary it is on Linux but we'll keep in for now)